### PR TITLE
Fix lengthy DEM load upon screen rotation or app resumption

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.openathena"
         minSdk 28
         targetSdk 32
-        versionCode 18
-        versionName "0.15.2"
+        versionCode 19
+        versionName "0.15.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         -->
 
     <application
+        android:name=".AthenaApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/openathena/AthenaActivity.java
+++ b/app/src/main/java/com/openathena/AthenaActivity.java
@@ -198,8 +198,6 @@ public abstract class AthenaActivity extends AppCompatActivity {
 
         int id = item.getItemId();
 
-        // don't do anything if they select prefs
-
         if (id == R.id.action_calculate) {
             // jump to main activity
             // its already created

--- a/app/src/main/java/com/openathena/AthenaApp.java
+++ b/app/src/main/java/com/openathena/AthenaApp.java
@@ -1,0 +1,14 @@
+package com.openathena;
+
+import android.app.Application;
+
+public class AthenaApp extends Application { // Android Singleton Class for holding state information
+    private GeoTIFFParser geoTIFFParser;
+    public GeoTIFFParser getGeoTIFFParser() {
+        return geoTIFFParser;
+    }
+
+    public synchronized void setGeoTIFFParser(GeoTIFFParser geoTIFFParser) {
+        this.geoTIFFParser = geoTIFFParser;
+    }
+}

--- a/app/src/main/java/com/openathena/GeoTIFFParser.java
+++ b/app/src/main/java/com/openathena/GeoTIFFParser.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import java.io.Console;
 import java.io.File;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,19 +25,20 @@ import com.openathena.geodataAxisParams;
 
 import mil.nga.tiff.*;
 
-public class GeoTIFFParser {
+public class GeoTIFFParser implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     public static String TAG = GeoTIFFParser.class.getSimpleName();
 
-    private File geofile;
+    private transient File geofile;
 
-    private TIFFImage tiffImage;
-    private List<FileDirectory> directories;
-    private FileDirectory directory;
-    private Rasters rasters;
+    private transient TIFFImage tiffImage;
+    private transient List<FileDirectory> directories;
+    private transient FileDirectory directory;
+    private Rasters rasters; // implements Serializable
 
-    private geodataAxisParams xParams;
-    private geodataAxisParams yParams;
+    private geodataAxisParams xParams; // implements Serializable
+    private geodataAxisParams yParams; // implements Serializable
 
     GeoTIFFParser() {
         geofile = null;
@@ -182,7 +185,7 @@ public class GeoTIFFParser {
      * @throws RequestedValueOOBException
      */
     public double getAltFromLatLon(double lat, double lon) throws RequestedValueOOBException {
-        if (geofile == null || rasters == null || xParams == null || yParams == null) {
+        if (rasters == null || xParams == null || yParams == null) {
             throw new NullPointerException("getAltFromLatLon pre-req was null!");
         }
         if ( xParams.numOfSteps <= 0 || yParams.numOfSteps <= 0) {
@@ -236,10 +239,10 @@ public class GeoTIFFParser {
     }
 
     /**
-     * Performs a binary search, returning indicies pointing to the two closest values to the input
+     * Performs a binary search, returning indices pointing to the two closest values to the input
      * @param start the start value, in degrees, of an axis of the geofile
      * @param n the number of items in an axis of the geofile
-     * @param val an input value for which to find the two closest indicies
+     * @param val an input value for which to find the two closest indices
      * @param dN the change in value for each increment of the index along an axis of the geofile
      * @return
      */
@@ -294,7 +297,7 @@ public class GeoTIFFParser {
 
         // if we've broken out of the loop, L > R
         //     which means the markers have flipped
-        //     therfore, either list[L] or list[R] must be closest to val
+        //     therefore, either list[L] or list[R] must be closest to val
         return new long[]{R, L};
     }
 }

--- a/app/src/main/java/com/openathena/MainActivity.java
+++ b/app/src/main/java/com/openathena/MainActivity.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -186,7 +187,6 @@ public class MainActivity extends AthenaActivity {
         // append
 
         clearText();
-//        appendLog("OpenAthena™ for Android version "+versionName+"\nMatthew Krupczak, Bobby Krupczak, et al.\n GPL-3.0, some rights reserved\n");
 
         if (savedInstanceState != null) {
             CharSequence textRestore = savedInstanceState.getCharSequence("textview");
@@ -196,6 +196,24 @@ public class MainActivity extends AthenaActivity {
             CharSequence textViewTargetCoordRestore = savedInstanceState.getCharSequence("textViewTargetCoord");
             if (textViewTargetCoordRestore != null) {
                 textViewTargetCoord.setText(textViewTargetCoordRestore);
+            }
+
+            // restore previously loaded DEM
+            Object obj = savedInstanceState.getSerializable("theParser");
+            if (obj == null) {
+                Log.d(TAG, "theParser was null in savedInstanceState");
+            }
+            if (obj instanceof GeoTIFFParser) {
+                Log.d(TAG, "theParser restored successfully!");
+                theParser = (GeoTIFFParser) obj;
+                theTGetter = new TargetGetter(theParser);
+                try {
+                    Log.d(TAG, "alt at start point is: " + theParser.getAltFromLatLon(33.837189, -84.53877));
+                } catch (RequestedValueOOBException e) {
+                    e.printStackTrace();
+                }
+                isDEMLoaded = true;
+                setButtonReady(buttonSelectImage, true);
             }
 
             String storedUriString = savedInstanceState.getString("imageUri");
@@ -214,12 +232,14 @@ public class MainActivity extends AthenaActivity {
                 }
             }
 
-            String storedDEMUriString = savedInstanceState.getString("demUri");
-            Log.d(TAG, "loaded demUri: " + storedDEMUriString);
-            if (storedDEMUriString != null) {
-                demUri = Uri.parse(storedDEMUriString);
-                demSelected(demUri);
-            }
+            // // old way of restoring loaded DEM
+//            String storedDEMUriString = savedInstanceState.getString("demUri");
+//            Log.d(TAG, "loaded demUri: " + storedDEMUriString);
+//            if (storedDEMUriString != null) {
+//                demUri = Uri.parse(storedDEMUriString);
+//                demSelected(demUri);
+//            }
+
             isTargetCoordDisplayed = savedInstanceState.getBoolean("isTargetCoordDisplayed");
             isImageLoaded = savedInstanceState.getBoolean("isImageLoaded");
             // // handled by demSelected(demUri) above, will change in later version
@@ -277,9 +297,12 @@ public class MainActivity extends AthenaActivity {
         if (imageUri != null) {
             saveInstanceState.putString("imageUri", imageUri.toString());
         }
-        if (demUri != null) {
-            Log.d(TAG, "saved demUri: " + demUri.toString());
-            saveInstanceState.putString("demUri", demUri.toString());
+//        if (demUri != null) {
+//            Log.d(TAG, "saved demUri: " + demUri.toString());
+//            saveInstanceState.putString("demUri", demUri.toString());
+//        }
+        if (theParser != null) {
+            saveInstanceState.putSerializable("theParser", theParser);
         }
         if (selection_x >= 0) {
             saveInstanceState.putInt("selection_x", selection_x);
@@ -287,6 +310,7 @@ public class MainActivity extends AthenaActivity {
         if (selection_y >= 0) {
             saveInstanceState.putInt("selection_y", selection_y);
         }
+
 //        if (cx >= 0) {
 //            saveInstanceState.putInt("cx", cx);
 //        }

--- a/app/src/main/java/com/openathena/geodataAxisParams.java
+++ b/app/src/main/java/com/openathena/geodataAxisParams.java
@@ -1,5 +1,8 @@
 package com.openathena;
-class geodataAxisParams {
+
+import java.io.Serializable;
+
+class geodataAxisParams implements Serializable {
     double start;
     double end;
     double stepwiseIncrement;

--- a/app/src/main/java/mil/nga/tiff/FieldType.java
+++ b/app/src/main/java/mil/nga/tiff/FieldType.java
@@ -1,5 +1,7 @@
 package mil.nga.tiff;
 
+import java.io.Serializable;
+
 import mil.nga.tiff.util.TiffConstants;
 import mil.nga.tiff.util.TiffException;
 
@@ -8,7 +10,7 @@ import mil.nga.tiff.util.TiffException;
  * 
  * @author osbornb
  */
-public enum FieldType {
+public enum FieldType implements Serializable {
 
 	/**
 	 * 8-bit unsigned integer


### PR DESCRIPTION
There has been an issue with the UI (#43) for a while now, where rotating the screen or leaving the app and re-entering it would trigger  a lengthy re-load of the selected Digital Elevation Model from disk. Depending on the size of the selected GeoTIFF file, this could take over a minute in the worst case.

This PR creates a custom Application Singleton "AthenaApp" and uses it to store the Digital Elevation Model as a persistent object. DEM re-load from disk is now a fallback option only if loading from memory fails.

