### PR TITLE
Fix #85 Add Automated DEM Download and Loading

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
+
+
     <!-- Chromebook compatibility -->
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -58,6 +60,16 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.OpenAthenaAndroid"
         tools:targetApi="31">
+        <!-- used for share DEM button -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <activity
             android:name=".DemCacheActivity"
             android:exported="false"

--- a/app/src/main/java/com/openathena/AthenaApp.java
+++ b/app/src/main/java/com/openathena/AthenaApp.java
@@ -17,6 +17,11 @@ public class AthenaApp extends Application { // Android Singleton Class for hold
     public static String TAG = AthenaApp.class.getSimpleName();
 
     public static final double FEET_PER_METER = 3937.0d/1200.0d; // Exact constant for US Survey Foot per Meter
+    public static final double FEET_PER_MILE = 5280.0d;
+
+    public static final double DEM_DOWNLOAD_DEFAULT_METERS_DIAMETER = 15000.0d;
+    // https://earthscience.stackexchange.com/questions/7283/how-high-must-one-be-for-the-curvature-of-the-earth-to-be-visible-to-the-eye
+    public static final double DEM_DOWNLOAD_RETRY_MAX_METERS_DIAMETER = 25000.0d;
 
     @Override
     public void onCreate() {

--- a/app/src/main/java/com/openathena/DEMParser.java
+++ b/app/src/main/java/com/openathena/DEMParser.java
@@ -23,7 +23,6 @@ import mil.nga.tiff.*;
 import mil.nga.tiff.util.TiffException;
 
 public class DEMParser implements Serializable {
-    private static final long serialVersionUID = 1L;
 
     public static String TAG = DEMParser.class.getSimpleName();
 

--- a/app/src/main/java/com/openathena/DemCache.java
+++ b/app/src/main/java/com/openathena/DemCache.java
@@ -142,7 +142,7 @@ public class DemCache {
                             clon = v[1];
                             l = v[2];
 
-                            Uri fileUri = Uri.fromFile(new File(appDir,filename));
+                            Uri fileUri = Uri.fromFile(file);
                             DemCacheEntry aDem = new DemCacheEntry(filename,fileUri,n,s,e,w,l,clat,clon,createDate,modDate,fileSize);
                             cache.add(aDem);
                             totalBytes += aDem.bytes;

--- a/app/src/main/java/com/openathena/DemCache.java
+++ b/app/src/main/java/com/openathena/DemCache.java
@@ -99,6 +99,14 @@ public class DemCache {
 
     } // DemCache() constructor
 
+    public String getAreaSizeString(DemCacheEntry dce, boolean isDistanceUnitImperial) {
+        AthenaApp athenaApp = (AthenaApp) context.getApplicationContext();
+        if (dce == null) {
+            return athenaApp.getString(R.string.error_nondescript);
+        }
+        return ((isDistanceUnitImperial) ? Math.round(dce.l * Math.pow(AthenaApp.FEET_PER_METER,2.0d) / Math.pow(AthenaApp.FEET_PER_MILE,2.0d)) : Math.round(dce.l / Math.pow(1000.0d,2.0d))) + " " + (isDistanceUnitImperial ? "mi" : "km") + "²";
+    }
+
     // refresh the cache after say new downloads or imports XXX
 
     public void refreshCache()

--- a/app/src/main/java/com/openathena/DemCache.java
+++ b/app/src/main/java/com/openathena/DemCache.java
@@ -67,6 +67,7 @@ public class DemCache {
     public long totalBytes = 0;
     public List<DemCacheEntry> cache;
     public Context context;
+    protected File demDir;
     public int selectedItem = -1;
 
     public DemCache(Context context)
@@ -74,8 +75,12 @@ public class DemCache {
         // read/scan app document/storage directory for .tiff files
         // DEM_LatLon_s_w_n_e.tiff
         this.context = context;
+        if (context == null) {
+            throw new IllegalArgumentException("ERROR: tried to initialize DemCache object with a null Context!");
+        }
 
         Log.d(TAG,"DemCache: starting");
+        demDir = new File(context.getCacheDir(), "DEMs");
 
         refreshCache();
 
@@ -99,14 +104,12 @@ public class DemCache {
     public void refreshCache()
     {
 
-        File appDir = context.getFilesDir();
-
         // reset the array list
         cache = new ArrayList<DemCacheEntry>();
         selectedItem = -1;
 
-        // list all .tiff files in the main app dir
-        File[] files = appDir.listFiles((dir,name) -> name.toLowerCase().endsWith(".tiff"));
+        // list all .tiff files in the demDir in app cache folder
+        File[] files = demDir.listFiles((dir,name) -> name.toLowerCase().endsWith(".tiff"));
         if (files != null) {
 
             Log.d(TAG,"DemCache: found "+files.length+" files to look at");
@@ -181,7 +184,7 @@ public class DemCache {
             Log.d(TAG,"DemCache: deleting "+removed.filename);
             String aFilename = removed.filename+".tiff";
 
-            File file = new File(context.getFilesDir(),aFilename);
+            File file = new File(demDir,aFilename);
             boolean ret = file.delete();
 
             if (!ret) {

--- a/app/src/main/java/com/openathena/DemCache.java
+++ b/app/src/main/java/com/openathena/DemCache.java
@@ -57,6 +57,10 @@ public class DemCache {
 
         } // DemCacheEntry constructor
 
+        public boolean contains(double lat, double lon) {
+            return (lat <= n && lat >= s && lon >= w && lon <= e);
+        }
+
     } // class DemCacheEntry
 
     // DemCache instance variables
@@ -216,7 +220,7 @@ public class DemCache {
         DemCacheEntry bestEntry = null;
 
         for (DemCacheEntry entry : cache) {
-            if (lat < entry.n && lat > entry.s && lon > entry.w && lon < entry.e) {
+            if (entry.contains(lat,lon)) {
                 // Calculate coverage as the minimum distance to the boundary from the search position
                 double northCoverage = Math.abs(entry.n - lat);
                 double southCoverage = Math.abs(lat - entry.s);

--- a/app/src/main/java/com/openathena/DemCache.java
+++ b/app/src/main/java/com/openathena/DemCache.java
@@ -12,20 +12,13 @@
 
 package com.openathena;
 
-import java.lang.annotation.Target;
-import java.nio.file.attribute.FileTime;
 import java.util.Date;
 import java.io.File;
-import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
-
-
-import androidx.core.util.Consumer;
 
 public class DemCache {
 
@@ -33,6 +26,7 @@ public class DemCache {
 
     public class DemCacheEntry {
         String filename;
+        Uri fileUri;
         double n; // north lat
         double e; // east lon
         double s; // south lat
@@ -44,11 +38,12 @@ public class DemCache {
         Date modDate;
         long bytes;
 
-        public DemCacheEntry(String filename, double n, double s, double e, double w,
+        public DemCacheEntry(String filename, Uri fileUri, double n, double s, double e, double w,
                              double l, double cLat, double cLon, Date createDate, Date modDate,
                              long bytes) {
 
             this.filename = filename;
+            this.fileUri = fileUri;
             this.n = n;
             this.s = s;
             this.e = e;
@@ -147,7 +142,8 @@ public class DemCache {
                             clon = v[1];
                             l = v[2];
 
-                            DemCacheEntry aDem = new DemCacheEntry(filename,n,s,e,w,l,clat,clon,createDate,modDate,fileSize);
+                            Uri fileUri = Uri.fromFile(new File(appDir,filename));
+                            DemCacheEntry aDem = new DemCacheEntry(filename,fileUri,n,s,e,w,l,clat,clon,createDate,modDate,fileSize);
                             cache.add(aDem);
                             totalBytes += aDem.bytes;
 

--- a/app/src/main/java/com/openathena/DemCacheActivity.java
+++ b/app/src/main/java/com/openathena/DemCacheActivity.java
@@ -108,7 +108,9 @@ public class DemCacheActivity extends AthenaActivity implements DemListAdapter.I
 
     private void refreshView()
     {
-        Log.d(TAG,"DemCacheActivity: refreshView "+athenaApp.demCache.cache.size()+" entries");
+        if (athenaApp.demCache != null) {
+            Log.d(TAG, "DemCacheActivity: refreshView " + athenaApp.demCache.cache.size() + " entries");
+        }
 
         adapter = new DemListAdapter(this,athenaApp.demCache);
         adapter.setClickListener(this);

--- a/app/src/main/java/com/openathena/DemDownloader.java
+++ b/app/src/main/java/com/openathena/DemDownloader.java
@@ -12,6 +12,7 @@ package com.openathena;
 import android.content.Context;
 import android.util.Log;
 
+import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.io.BufferedReader;
@@ -36,8 +37,15 @@ public class DemDownloader
     private String outputFormatStr = "GTiff";
     private Context context;
 
+    protected File demDir;
+
     public DemDownloader(Context appContext, double lat, double lon, double length) {
         context = appContext;
+        if (context == null) {
+            throw new IllegalArgumentException("ERROR: tried to initialize DemCache object with a null Context!");
+        }
+        demDir = new File(context.getCacheDir(), "DEMs");
+
         double[] boundingBox = getBoundingBox(lat, lon, length);
         n = boundingBox[0];
         s = boundingBox[1];
@@ -74,7 +82,7 @@ public class DemDownloader
 
         try {
             InputStream inputStream = connection.getInputStream();
-            FileOutputStream outputStream = context.openFileOutput(filename,Context.MODE_PRIVATE);
+            FileOutputStream outputStream = new FileOutputStream(new File(demDir,filename));
 
             byte[] buffer = new byte[4096];
             int bytesRead = 0;

--- a/app/src/main/java/com/openathena/DemDownloader.java
+++ b/app/src/main/java/com/openathena/DemDownloader.java
@@ -74,6 +74,7 @@ public class DemDownloader
         int responseCode = connection.getResponseCode();
         if (responseCode != HttpURLConnection.HTTP_OK) {
             Log.d(TAG,"DemDownloader: request failed, error code "+responseCode);
+            Log.d(TAG, "requestURLStr was: " + requestURLStr);
             return false;
         }
 
@@ -135,7 +136,7 @@ public class DemDownloader
                 }
                 catch (java.net.UnknownHostException uhe) {
                     if (consumer != null) {
-                        consumer.accept("Could not connect to" + " portal.opentopography.org.\n " + "Is your device connected to the Internet?");
+                        consumer.accept("Could not connect to" + " portal.opentopography.org for DEM download.\n " + "Is your device connected to the Internet?" + "\n\n" + "(" + context.getString(R.string.prompt_use_blah) + context.getString(R.string.action_demcache) + context.getString(R.string.to_import_an_offline_dem_file_manually) + "\n");
                     }
                 }
                 catch (java.net.SocketException se) {

--- a/app/src/main/java/com/openathena/DemManagementActivity.java
+++ b/app/src/main/java/com/openathena/DemManagementActivity.java
@@ -28,7 +28,7 @@ public abstract class DemManagementActivity extends AthenaActivity {
 
     protected ProgressBar progressBar;
     // semaphore value will be > 0 if a long process is currently running
-    protected int showProgressBarSemaphore = 0;
+    protected static int showProgressBarSemaphore;
 
 
     @Override
@@ -45,6 +45,11 @@ public abstract class DemManagementActivity extends AthenaActivity {
     protected void onResume() {
         super.onResume();
         lastPointOfInterest = athenaApp.getString("lastPointOfInterest");
+        if (showProgressBarSemaphore < 1) {
+            progressBar.setVisibility(View.GONE);
+        } else {
+            progressBar.setVisibility(View.VISIBLE);
+        }
     }
 
     @Override
@@ -58,10 +63,7 @@ public abstract class DemManagementActivity extends AthenaActivity {
             public void onLocationChanged(Location location) {
                 updateLatLonText(location);
                 locationManager.removeUpdates(this);
-                showProgressBarSemaphore--;
-                if (showProgressBarSemaphore<=0) {
-                    progressBar.setVisibility(View.GONE);
-                }
+                decrementProgressBar();
                 isGPSFixInProgress = false;
             }
 
@@ -137,13 +139,26 @@ public abstract class DemManagementActivity extends AthenaActivity {
     }
 
     protected void decrementProgressBar() {
-        Handler mainHandler = new Handler(Looper.getMainLooper());
-        mainHandler.post(new Runnable() {
+        runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 showProgressBarSemaphore--;
                 if (showProgressBarSemaphore <= 0) {
                     progressBar.setVisibility(View.GONE);
+                }
+            }
+        });
+    }
+
+    protected void incrementAndShowProgressBar() {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                showProgressBarSemaphore++;
+                if (showProgressBarSemaphore > 0) {
+                    progressBar.setVisibility(View.VISIBLE);
+                } else {
+                    Log.e(TAG, "ERROR: showProgressBarSemaphore had an invalid value!");
                 }
             }
         });

--- a/app/src/main/java/com/openathena/DemManagementActivity.java
+++ b/app/src/main/java/com/openathena/DemManagementActivity.java
@@ -92,11 +92,11 @@ public abstract class DemManagementActivity extends AthenaActivity {
             @Override
             public void accept(String s) {
                 Log.d(TAG,"NewDemActivity download returned "+s);
-                postResults(s);
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
                         decrementProgressBar();
+                        postResults(s);
                         Toast t = Toast.makeText(DemManagementActivity.this,s,Toast.LENGTH_SHORT);
                         t.setGravity(Gravity.CENTER,0,0);
                         t.show();

--- a/app/src/main/java/com/openathena/ElevationMapDetailsActivity.java
+++ b/app/src/main/java/com/openathena/ElevationMapDetailsActivity.java
@@ -158,7 +158,7 @@ public class ElevationMapDetailsActivity extends AthenaActivity
 
         htmlString += "<br>";
 
-        htmlString += "size: " + ((isUnitFoot()) ? Math.round(dEntry.l * AthenaApp.FEET_PER_METER) : Math.round(dEntry.l)) + " " + (isUnitFoot() ? "ft." : getString(R.string.meter_label)) + "²" + "<br>";
+        htmlString += "size: " + athenaApp.demCache.getAreaSizeString(dEntry,isUnitFoot()) + "<br>";
         String coordStr = truncateDouble(dEntry.cLat, 6)+","+truncateDouble(dEntry.cLon, 6);
 
         // Google Maps requires a ?q= tag to actually display a pin for the indicated location

--- a/app/src/main/java/com/openathena/ElevationMapDetailsActivity.java
+++ b/app/src/main/java/com/openathena/ElevationMapDetailsActivity.java
@@ -38,9 +38,10 @@ public class ElevationMapDetailsActivity extends AthenaActivity
     String exportFilename = "";
     DemCache.DemCacheEntry dEntry;
 
-    static TimeZone local_tz = TimeZone.getDefault();
-    static DateFormat df_ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+    static TimeZone local_tz;
+    static DateFormat df_ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+    protected File demDir;
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -50,6 +51,9 @@ public class ElevationMapDetailsActivity extends AthenaActivity
         demInfo = (TextView)findViewById(R.id.elevationMapDetailText);
         demInfo.setMovementMethod(LinkMovementMethod.getInstance());
 
+        demDir = new File(getCacheDir(), "DEMs");
+
+        local_tz = TimeZone.getDefault();
         df_ISO8601.setTimeZone(local_tz);
 
         // create the activity launcher here;
@@ -61,7 +65,7 @@ public class ElevationMapDetailsActivity extends AthenaActivity
                 // dialog gives us a URI, we need to open/read/write exported file
                 // the try with resources statement automatically closes the streams
                 // when it finishes
-                try (InputStream inputStream = Files.newInputStream(new File(getFilesDir(), exportFilename).toPath());
+                try (InputStream inputStream = Files.newInputStream(new File(demDir, exportFilename).toPath());
                      OutputStream outStream = getContentResolver().openOutputStream(uri)) {
 
                     byte[] buf = new byte[1024];

--- a/app/src/main/java/com/openathena/ElevationMapDetailsActivity.java
+++ b/app/src/main/java/com/openathena/ElevationMapDetailsActivity.java
@@ -6,11 +6,14 @@
 
 package com.openathena;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.core.content.FileProvider;
 
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
@@ -39,6 +42,7 @@ public class ElevationMapDetailsActivity extends AthenaActivity
     DemCache.DemCacheEntry dEntry;
 
     static TimeZone local_tz;
+    @SuppressLint("SimpleDateFormat")
     static DateFormat df_ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     protected File demDir;
@@ -192,14 +196,34 @@ public class ElevationMapDetailsActivity extends AthenaActivity
     public boolean onOptionsItemSelected(MenuItem item)
     {
         Intent intent;
-
+        int itemID = item.getItemId();
         // Handle item selection
-        if (item.getItemId() == R.id.action_export_dem) {
+        if (itemID == R.id.action_export_dem) {
             Log.d(TAG, "DemDetail: going to export a DEM " + exportFilename);
             copyDemLauncher.launch(exportFilename);
             return true;
+        } else if (itemID == R.id.action_share_dem) {
+            Log.d(TAG, "DemDetail: going to share a DEM " + exportFilename);
+            shareDemFile(new File(demDir, exportFilename));
+            return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void shareDemFile(File file) {
+        try {
+            Uri fileUri = FileProvider.getUriForFile(this, getApplicationContext().getPackageName() + ".provider", file);
+
+            Intent shareIntent = new Intent();
+            shareIntent.setAction(Intent.ACTION_SEND);
+            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION); // Grant temporary read permission to the recipient
+            shareIntent.putExtra(Intent.EXTRA_STREAM, fileUri);
+            shareIntent.setType("application/octet-stream");
+            startActivity(Intent.createChooser(shareIntent, "Share DEM"));
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "The selected file can't be shared: " + file.toString());
+            Toast.makeText(this, "ERROR: failed to share your selected DEM file!", Toast.LENGTH_SHORT).show();
+        }
     }
 
     public void calculateImage(View view) { return; } // not used in this activity

--- a/app/src/main/java/com/openathena/MainActivity.java
+++ b/app/src/main/java/com/openathena/MainActivity.java
@@ -428,9 +428,13 @@ public class MainActivity extends DemManagementActivity {
                     appendText("Started DEM auto-load for your selected image" + "\n");
                     demSelected(matchingDemURI);
                 } else {
+                    showProgressBarSemaphore++;
+                    progressBar.setVisibility(View.VISIBLE);
                     downloadNewDEM(lat,lon, 15000);
                 }
             } else {
+                showProgressBarSemaphore++;
+                progressBar.setVisibility(View.VISIBLE);
                 downloadNewDEM(lat,lon, 15000);
             }
 
@@ -452,6 +456,7 @@ public class MainActivity extends DemManagementActivity {
         setButtonReady(buttonSelectDEM, false);
         setButtonReady(buttonCalculate, false);
 
+        showProgressBarSemaphore++;
         progressBar.setVisibility(View.VISIBLE);
 
         Handler myHandler = new Handler();
@@ -473,10 +478,10 @@ public class MainActivity extends DemManagementActivity {
                         if (isImageLoaded) {
                             setButtonReady(buttonCalculate, true);
                         }
-                        progressBar.setVisibility(View.GONE);
+                        decrementProgressBar();
                     } else {
                         appendText(e.getMessage());
-                        progressBar.setVisibility(View.GONE);
+                        decrementProgressBar();
                     }
                 }
             });
@@ -544,7 +549,7 @@ public class MainActivity extends DemManagementActivity {
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    progressBar.setVisibility(View.GONE);
+                    decrementProgressBar();
                     Toast.makeText(MainActivity.this, R.string.wrong_filetype_toast_error_msg, Toast.LENGTH_LONG).show();
                 }
             });

--- a/app/src/main/java/com/openathena/MainActivity.java
+++ b/app/src/main/java/com/openathena/MainActivity.java
@@ -89,7 +89,7 @@ public class MainActivity extends DemManagementActivity {
 
     TextView textView;
 
-    Button buttonSelectDEM;
+//    Button buttonSelectDEM;
     Button buttonSelectImage;
     Button buttonCalculate;
 
@@ -144,10 +144,10 @@ public class MainActivity extends DemManagementActivity {
         progressBar = (ProgressBar)  findViewById(R.id.progressBar);
         progressBar.setVisibility(View.GONE);
 
-        buttonSelectDEM = (Button) findViewById(R.id.selectDEMButton); // ⛰
+//        buttonSelectDEM = (Button) findViewById(R.id.selectDEMButton); // ⛰
         buttonSelectImage = (Button) findViewById(R.id.selectImageButton); // ð
         buttonCalculate = (Button) findViewById(R.id.calculateButton); // ð
-        setButtonReady(buttonSelectDEM, true);
+//        setButtonReady(buttonSelectDEM, true);
         setButtonReady(buttonSelectImage, true);
         setButtonReady(buttonCalculate, false);
 
@@ -425,14 +425,16 @@ public class MainActivity extends DemManagementActivity {
             if (dce != null) {
                 matchingDemURI = dce.fileUri;
                 if (dce.contains(lat,lon)) {
-                    appendText("Started DEM auto-load for your selected image" + "\n");
+                    appendText("Found a DEM in cache for your selected image. Starting DEM auto-load..." + "\n");
                     demSelected(matchingDemURI);
                 } else {
+                    appendText("No DEM found for your selected image.\nDownloading new DEM from internet..." + "\n");
                     showProgressBarSemaphore++;
                     progressBar.setVisibility(View.VISIBLE);
                     downloadNewDEM(lat,lon, 15000);
                 }
             } else {
+                appendText("No DEM found for your selected image.\nDownloading new DEM from internet..." + "\n");
                 showProgressBarSemaphore++;
                 progressBar.setVisibility(View.VISIBLE);
                 downloadNewDEM(lat,lon, 15000);
@@ -453,7 +455,7 @@ public class MainActivity extends DemManagementActivity {
 //        appendLog("Selected DEM " + uri + "\n");
 
         //    isDEMLoaded = false;
-        setButtonReady(buttonSelectDEM, false);
+//        setButtonReady(buttonSelectDEM, false);
         setButtonReady(buttonCalculate, false);
 
         showProgressBarSemaphore++;
@@ -511,18 +513,13 @@ public class MainActivity extends DemManagementActivity {
                     outputStream.close();
                     inputStream.close();
                 } catch (FileNotFoundException e) {
-                    // Handle the FileNotFoundException here
-                    // For example, you can show an error message to the user
-                    // or log the error to Crashlytics
                     Log.e(TAG, "FileNotFound demSelected()");
                     throw e;
                 } catch (IOException e) {
-                    // Handle other IOException here
-                    // For example, you can log the error to Crashlytics
                     e.printStackTrace();
                     throw e;
                 } finally {
-                    setButtonReady(buttonSelectDEM, true);
+//                    setButtonReady(buttonSelectDEM, true);
                 }
             } catch (Exception e) {
                 return e;
@@ -557,7 +554,7 @@ public class MainActivity extends DemManagementActivity {
             e.printStackTrace();
             return new Exception(failureOutput + "\n");
         } finally {
-            setButtonReady(buttonSelectDEM, true);
+//            setButtonReady(buttonSelectDEM, true);
             if (isDEMLoaded && isImageLoaded) {
                 setButtonReady(buttonCalculate, true);
             }
@@ -949,6 +946,7 @@ public class MainActivity extends DemManagementActivity {
         postResults(resultStr);
         DemCache.DemCacheEntry dce = athenaApp.demCache.searchCacheEntry(lat, lon);
         if (dce != null) {
+            appendText("Starting auto-load for downloaded DEM file..." + "\n");
             demSelected(dce.fileUri);
         }
     }

--- a/app/src/main/java/com/openathena/ManageDemsActivity.java
+++ b/app/src/main/java/com/openathena/ManageDemsActivity.java
@@ -53,7 +53,11 @@ public class ManageDemsActivity extends DemManagementActivity
         resultsButton = (Button)findViewById(R.id.lookupResultsButton);
 
         progressBar = (ProgressBar)  findViewById(R.id.progressBar);
-        progressBar.setVisibility(View.GONE);
+        if (showProgressBarSemaphore < 1) {
+            progressBar.setVisibility(View.GONE);
+        } else {
+            progressBar.setVisibility(View.VISIBLE);
+        }
 
         // If user has previously obtained self GPS location in another DemManagementActivity,
         //     load the result into this activity to save them time

--- a/app/src/main/java/com/openathena/NewElevationMapActivity.java
+++ b/app/src/main/java/com/openathena/NewElevationMapActivity.java
@@ -53,13 +53,17 @@ public class NewElevationMapActivity extends DemManagementActivity
     private LocationManager locationManager;
     private LocationListener locationListener;
 
+    protected File demDir;
+
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
-        Log.d(TAG,"NewDemActivity onCreate started");
+        Log.d(TAG,"NewElevationMapActivity onCreate started");
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_new_dem);
+
+        demDir = new File(getCacheDir(), "DEMs");
 
         instructionsLabel = (TextView)findViewById(R.id.new_dem_label);
         getPosGPSButton = (ImageButton) findViewById(R.id.get_pos_gps_button);
@@ -102,7 +106,7 @@ public class NewElevationMapActivity extends DemManagementActivity
         // create the activityresultlauncher here because of various threading
         // constraints
         importLauncher = registerForActivityResult(new ActivityResultContracts.GetContent(), uri -> {
-            Log.d(TAG,"NewDemActivity: picked a file!");
+            Log.d(TAG,"NewElevationMapActivity: picked a file!");
             if (uri != null) {
                 copyFileToPrivateStorage(uri);
             }
@@ -143,7 +147,7 @@ public class NewElevationMapActivity extends DemManagementActivity
         String meters = metersText.getText().toString();
         double lat = 0, lon = 0, h = 15000;
 
-        Log.d(TAG,"NewDemActivity going to download from InterWebs");
+        Log.d(TAG,"NewElevationMapActivity going to download from InterWebs");
 
         // hide the keyboard
         InputMethodManager im = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -220,7 +224,7 @@ public class NewElevationMapActivity extends DemManagementActivity
                     return;
                 }
 
-                File importFile = new File(getFilesDir(), "import.tiff");
+                File importFile = new File(demDir, "import.tiff");
                 DEMParser aParser = new DEMParser(importFile);
                 if (aParser == null) {
                     postResults("Are you sure this was a GeoTIFF file?");
@@ -234,7 +238,7 @@ public class NewElevationMapActivity extends DemManagementActivity
                 double w = truncateDouble(aParser.getMinLon(), 6);
                 String newFilename = "DEM_LatLon_" + s + "_" + w + "_" + n + "_" + e + ".tiff";
 
-                File newFile = new File(getFilesDir(), newFilename);
+                File newFile = new File(demDir, newFilename);
                 if (newFile.exists() && !newFile.delete()) {
                     postResults("Failed to import file of same name");
                     decrementProgressBar();
@@ -271,7 +275,7 @@ public class NewElevationMapActivity extends DemManagementActivity
     // handle an import button click
     private void onClickImport()
     {
-        Log.d(TAG,"NewDemActivity: going to pick a file to import");
+        Log.d(TAG,"NewElevationMapActivity: going to pick a file to import");
         // launch and give it .tiff as a restriction?
         // launcher takes mime-types; here are a few options
         // image/tiff -- just tiff files

--- a/app/src/main/java/com/openathena/NewElevationMapActivity.java
+++ b/app/src/main/java/com/openathena/NewElevationMapActivity.java
@@ -73,8 +73,11 @@ public class NewElevationMapActivity extends DemManagementActivity
         importButton = (Button)findViewById(R.id.new_dem_importbutton);
 
         progressBar = (ProgressBar)  findViewById(R.id.progressBar);
-        progressBar.setVisibility(View.GONE);
-        showProgressBarSemaphore = 0;
+        if (showProgressBarSemaphore < 1) {
+            progressBar.setVisibility(View.GONE);
+        } else {
+            progressBar.setVisibility(View.VISIBLE);
+        }
 
         resultsLabel = (TextView)findViewById(R.id.new_dem_results);
 
@@ -132,8 +135,7 @@ public class NewElevationMapActivity extends DemManagementActivity
         if (!isGPSFixInProgress && showProgressBarSemaphore > 0) {
             return;
         }
-        showProgressBarSemaphore++;
-        progressBar.setVisibility(View.VISIBLE);
+        incrementAndShowProgressBar();
 
         String latlon = latLonText.getText().toString();
         latlon = latlon.trim();
@@ -202,8 +204,7 @@ public class NewElevationMapActivity extends DemManagementActivity
         if (filePath == null) filePath = "";
         resultsLabel.setText("Importing file, please wait...");
 
-        showProgressBarSemaphore++;
-        progressBar.setVisibility(View.VISIBLE);
+        incrementAndShowProgressBar();
 
         new Thread(new Runnable() {
             @Override

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -18,7 +18,7 @@
         android:textSize="24dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/scrollView2"
-        app:layout_constraintTop_toBottomOf="@+id/selectDEMButton" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/calculateButton"
@@ -92,19 +92,19 @@
             android:textSize="18sp" />
     </ScrollView>
 
-    <Button
-        android:id="@+id/selectDEMButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="13dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginEnd="24dp"
-        android:onClick="selectDEM"
-        android:text="@string/button_loadDEM"
-        android:textSize="24dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/scrollView2"
-        app:layout_constraintTop_toTopOf="parent" />
+<!--    <Button-->
+<!--        android:id="@+id/selectDEMButton"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:layout_marginStart="13dp"-->
+<!--        android:layout_marginTop="24dp"-->
+<!--        android:layout_marginEnd="24dp"-->
+<!--        android:onClick="selectDEM"-->
+<!--        android:text="@string/button_loadDEM"-->
+<!--        android:textSize="24dp"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        app:layout_constraintStart_toEndOf="@+id/scrollView2"-->
+<!--        app:layout_constraintTop_toTopOf="parent" />-->
 
     <TextView
         android:id="@+id/textViewTargetCoord"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -82,17 +82,17 @@
             android:textSize="18dp" />
     </ScrollView>
 
-    <Button
-        android:id="@+id/selectDEMButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="36dp"
-        android:layout_marginTop="36dp"
-        android:onClick="selectDEM"
-        android:text="@string/button_loadDEM"
-        android:textSize="24sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+<!--    <Button-->
+<!--        android:id="@+id/selectDEMButton"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:layout_marginStart="36dp"-->
+<!--        android:layout_marginTop="36dp"-->
+<!--        android:onClick="selectDEM"-->
+<!--        android:text="@string/button_loadDEM"-->
+<!--        android:textSize="24sp"-->
+<!--        app:layout_constraintStart_toStartOf="parent"-->
+<!--        app:layout_constraintTop_toTopOf="parent" />-->
 
     <TextView
         android:id="@+id/textViewTargetCoord"

--- a/app/src/main/res/menu/dem_detail_menu.xml
+++ b/app/src/main/res/menu/dem_detail_menu.xml
@@ -4,8 +4,14 @@
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
         <item
-            android:id="@+id/action_export_dem"
+            android:id="@+id/action_share_dem"
             android:icon="@android:drawable/ic_menu_share"
-            android:title="Export DEM"
+            android:title="Share DEM"
             app:showAsAction="ifRoom" />
+
+        <item
+            android:id="@+id/action_export_dem"
+            android:icon="@android:drawable/ic_menu_upload"
+            android:title="Export DEM"
+            app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="previous">Previous</string>
 
     <!-- TODO add proper translations once AUTODEM feature is complete!!! -->
-    <string name="action_demcache" translatable="false">Manage Elevation Maps</string>
+    <string name="action_demcache" translatable="false">Manage Digital Elevation Models</string>
 
     <string name="action_prefs">Settings</string>
     <string name="action_calculate">Calculate</string>
@@ -33,10 +33,10 @@
     <string name="title_activity_prefs">OpenAthena™ for Android Settings</string>
     <string name="title_activity_about">About OpenAthena™ for Android</string>
     <!-- TODO add proper translations once AUTODEM feature is complete!!! -->
-    <string name="title_activity_demcache" translatable="false">Manage Elevation Map Cache</string>
-    <string name="title_activity_newelevationmap" translatable="false">New Elevation Map</string>
-    <string name="title_activity_managedems" translatable="false">Manage Elevation Maps</string>
-    <string name="title_activity_mapsdetail" translatable="false">Elevation Map Details</string>
+    <string name="title_activity_demcache" translatable="false">Manage Elevation Models Cache</string>
+    <string name="title_activity_newelevationmap" translatable="false">New Elevation Models</string>
+    <string name="title_activity_managedems" translatable="false">Manage Elevation Models</string>
+    <string name="title_activity_mapsdetail" translatable="false">Elevation Model Details</string>
 
     <!-- TODO add proper translations once AUTODEM feature is complete!!! -->
     <string name="button_download_elevation_map" translatable="false">Download</string>
@@ -86,6 +86,7 @@
     <string name="i_understand_this_risk">I understand this risk</string>
     <string name="image_is_too_large_error_msg">Image is too large to show!</string>
     <string name="loading_geotiff_toast_msg">Loading DEM. Please wait...</string>
+    <string name="dem_loading_finished_user_interaction_prompt">DEM loaded successfully! Tap anywhere within the image to calculate coordinates</string>
     <string name="wgs84_standard_lat_lon">WGS84 (Default)\nLat, Lon</string>
     <string name="wgs84_tooltip">The widely-used standard for describing a latitude longitude location on Earth</string>
     <string name="nato_mgrs_1m">NATO MGRS 1m</string>
@@ -200,7 +201,10 @@
     </string>
     <string name="utm" translatable="false">UTM</string>
     <string name="utm_tooltip">Universal Transverse Mercator map projection system with 60 planar zones</string>
-    <string name="target_predicted_ce">"Predicted circular error:"</string>
+    <string name="target_predicted_ce">"Predicted max circular error:"</string>
     <string name="target_location_error_category">Target Location Error Category:</string>
     <string name="missing_camera_intrinsics_warning_message">DANGER: Camera internal properties were not found in database. Calculation accuracy will be degraded. Email support@theta.limited</string>
+    <string name="prompt_use_blah">(use \"</string>
+    <string name="to_import_an_offline_dem_file_manually">\" to import an offline DEM file manually)</string>
+    <string name="error_nondescript">ERROR</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!--  File path of DEM Cache directory, used when user presses share button in ElevationMapDetailsActivity  -->
+    <cache-path name="shared_files" path="DEMs/" />
+</paths>


### PR DESCRIPTION
This PR adds adds support for #85, Automate DEM Download And Loading

e.g.:
https://github.com/Theta-Limited/OpenAthenaAndroid/assets/25494111/c7c0ac85-7262-4bdf-9c91-8d6b7aa58745


Users having to manually download and then load a DEM was previously the biggest pain point of this application. Automating this process has made use of the app significantly more tractable for the average drone user. 

Still need to do some UI touch up and localization tasks before ready for v0.21.0 release, however the feature is now stable enough to be on the master branch.