### PR TITLE
fix #189 refine target location error estimation using two-factor linear model

### DIFF
--- a/app/src/main/java/com/openathena/MarkableImageView.java
+++ b/app/src/main/java/com/openathena/MarkableImageView.java
@@ -525,6 +525,10 @@ public class MarkableImageView extends androidx.appcompat.widget.AppCompatImageV
 
     public int calculateInSampleSize(
             BitmapFactory.Options options, int reqWidth, int reqHeight) {
+        if (reqWidth <= 0 || reqHeight <= 0) {
+            return 1;
+        }
+
         // Raw height and width of image
         final int height = options.outHeight;
         final int width = options.outWidth;
@@ -540,6 +544,7 @@ public class MarkableImageView extends androidx.appcompat.widget.AppCompatImageV
             while ((halfHeight / inSampleSize) >= reqHeight
                     && (halfWidth / inSampleSize) >= reqWidth) {
                 inSampleSize *= 2;
+                Log.d(TAG, "inSampleSize: " + inSampleSize);
             }
         }
 

--- a/app/src/main/java/com/openathena/TLE_Model_Parameters.java
+++ b/app/src/main/java/com/openathena/TLE_Model_Parameters.java
@@ -1,4 +1,21 @@
 package com.openathena;
 
+/**
+ * Encapsulation class for storing parameters of 2 factor linear model for target location error estimation
+ */
 public class TLE_Model_Parameters {
+
+    // represents the y intercept (starting value) for the target location error linear model for a given drone
+    // This is usually around 5.25 meters, which may be attributed to the (in)accuracy of common GPS units.
+    public double tle_model_y_intercept;
+    // represents how much (in meters) each additional meter of distance adds to target location error for this drone. Slant range has routinely been observed as the primary factor influencing target location error. Values between 0.02 and 0.035 meters error per meter distance are typical.
+    public double tle_model_slant_range_coeff;
+    // represents how the vertical:horizontal distance slant ratio effects target location error. This may often be a negative value given that a steeper slant angle typically results in less target location error. If this factor was determined to be statistically-insignificant for a given drone, it is replaced in the model with 0.0
+    public double tle_model_slant_ratio_coeff;
+
+    public TLE_Model_Parameters(double tle_model_y_intercept, double tle_model_slant_range_coeff, double tle_model_slant_ratio_coeff) {
+        this.tle_model_y_intercept = tle_model_y_intercept;
+        this.tle_model_slant_range_coeff = tle_model_slant_range_coeff;
+        this.tle_model_slant_ratio_coeff = tle_model_slant_ratio_coeff;
+    }
 }

--- a/app/src/main/java/com/openathena/TLE_Model_Parameters.java
+++ b/app/src/main/java/com/openathena/TLE_Model_Parameters.java
@@ -1,0 +1,4 @@
+package com.openathena;
+
+public class TLE_Model_Parameters {
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,4 +304,6 @@
     <string name="extended_mode_enabled">Extended/debug CoT mode ON</string>
     <string name="extended_mode_disabled">Extended/debug CoT mode OFF</string>
     <string name="attribs_extended_cot_enabled_notification">"Extended Cursor on Target output: "</string>
+    <string name="attribs_is_tle_estimation_calibrated_for_this_drone">Is Target Location Error estimation calibrated for this drone model?:</string>
+    <string name="attribs_tle_prediction_model_parameters">TLE prediction model parameters:</string>
 </resources>


### PR DESCRIPTION
The OpenAthena software's previous method for estimating Target Location Error (TLE) was based only on slant angle from drone to target. 

In multiple experiments we've done on empirical data using the [OA-Accuracy-Testing framework however](https://github.com/Theta-Limited/OA-Accuracy-Testing), it has been demonstrated repeatedly that distance from drone to target (slant range) has a far more significant impact on TLE than slant angle. 

This would cause the TLE estimate to be far lower than the actual error when operating at extreme distances.

In this PR, a new TLE estimation method is implemented which integrates a two factor linear model that accounts for both slant range and slant angle.

For some drone models where the effect of slant angle was determined to be statistically-insignificant, a one factor linear model which just uses slant range is used instead.

for more details, see:
https://github.com/Theta-Limited/DroneModels?tab=readme-ov-file#target-location-error-tle-estimation-model-parameters
and 
https://github.com/Theta-Limited/OA-Accuracy-Testing